### PR TITLE
Remove devices from inventory

### DIFF
--- a/homie-ota.py
+++ b/homie-ota.py
@@ -301,6 +301,21 @@ def update():
 
     return info
 
+@route('/devices/<device_id>', method='DELETE')
+def delete_device(device_id):
+    topics = "%s/%s/+/+" % (MQTT_SENSOR_PREFIX, device_id)
+    mqttc.message_callback_add(topics, on_delete_message)
+    logging.info("Starting delete of topics for device %s" % (device_id))
+
+    # Give the callback 4 seconds before returning
+    sleep(4)
+
+    mqttc.message_callback_remove(topics)
+    info = "Deleted topics for %s" % (device)
+    logging.info(info)
+
+    return info
+
 def scan_firmware():
     fw = {}
     for fw_file in os.listdir(OTA_FIRMWARE_ROOT):
@@ -419,6 +434,14 @@ def ota():
 def on_connect(mosq, userdata, rc):
     mqttc.subscribe("%s/+/+" % (MQTT_SENSOR_PREFIX), 0)
     mqttc.subscribe("%s/+/+/+" % (MQTT_SENSOR_PREFIX), 0)
+
+# on_delete_message handles deleting the topic the messages was received on.
+def on_delete_message(mosq, userdata, msg):
+    logging.debug("Received delete callback for topic '%s'" % msg.topic)
+    if len(msg.topic) == 0
+        return
+    # Publish a retain message of zero bytes.
+    mqttc.publish(mst.topic, payload='', qos=1, retain=True)
 
 def on_sensor(mosq, userdata, msg):
     if msg.topic.endswith("$ota/payload"):

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -304,13 +304,17 @@ def update():
 @route('/device/<device_id>', method='DELETE')
 def delete_device(device_id):
     topics = "%s/%s/+/+" % (MQTT_SENSOR_PREFIX, device_id)
+    mqttc.loop_stop()
     mqttc.message_callback_add(topics, on_delete_message)
+    mqttc.loop_start()
     logging.info("Starting delete of topics for device %s" % (device_id))
 
-    # Give the callback 4 seconds before returning
-    time.sleep(4)
+    # Give the callback 10 seconds before returning
+    time.sleep(10)
 
+    mqttc.loop_stop()
     mqttc.message_callback_remove(topics)
+    mqttc.loop_start()
     info = "Deleted topics for %s" % (device_id)
     logging.info(info)
 

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -444,7 +444,7 @@ def on_connect(mosq, userdata, rc):
 # on_delete_message handles deleting the topic the messages was received on.
 def on_delete_message(mosq, userdata, msg):
     logging.debug("Received delete callback for topic '%s'" % msg.topic)
-    if len(msg.topic) == 0:
+    if len(msg.payload) == 0:
         return
     # Publish a retain message of zero bytes.
     mqttc.publish(msg.topic, payload='', qos=1, retain=True)

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -301,6 +301,7 @@ def update():
 
     return info
 
+# Handle deleting a device from the mqtt broker, and the local db.
 @route('/device/<device_id>', method='DELETE')
 def delete_device(device_id):
     topics = "%s/%s/#" % (MQTT_SENSOR_PREFIX, device_id)
@@ -310,8 +311,8 @@ def delete_device(device_id):
     mqttc.loop_start()
     logging.info("Starting delete of topics for device %s" % (device_id))
 
-    # Give the callback 4 seconds before returning
-    time.sleep(4)
+    # Give the callback time before returning
+    time.sleep(2)
 
     mqttc.loop_stop()
     mqttc.message_callback_remove(topics)
@@ -319,6 +320,7 @@ def delete_device(device_id):
     mqttc.loop_start()
     info = "Deleted topics for %s" % (device_id)
     logging.info(info)
+    del db[device_id]
 
     return info
 

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -303,15 +303,15 @@ def update():
 
 @route('/device/<device_id>', method='DELETE')
 def delete_device(device_id):
-    topics = "%s/%s/+/+" % (MQTT_SENSOR_PREFIX, device_id)
+    topics = "%s/%s/#" % (MQTT_SENSOR_PREFIX, device_id)
     mqttc.loop_stop()
     mqttc.subscribe(topics, 0)
     mqttc.message_callback_add(topics, on_delete_message)
     mqttc.loop_start()
     logging.info("Starting delete of topics for device %s" % (device_id))
 
-    # Give the callback 10 seconds before returning
-    time.sleep(10)
+    # Give the callback 4 seconds before returning
+    time.sleep(4)
 
     mqttc.loop_stop()
     mqttc.message_callback_remove(topics)
@@ -447,7 +447,7 @@ def on_delete_message(mosq, userdata, msg):
     if len(msg.payload) == 0:
         return
     # Publish a retain message of zero bytes.
-    mqttc.publish(msg.topic, payload='', qos=0, retain=True)
+    mqttc.publish(msg.topic, payload='', qos=1, retain=True)
 
 def on_sensor(mosq, userdata, msg):
     if msg.topic.endswith("$ota/payload"):

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -305,6 +305,7 @@ def update():
 def delete_device(device_id):
     topics = "%s/%s/+/+" % (MQTT_SENSOR_PREFIX, device_id)
     mqttc.loop_stop()
+    mqttc.subscribe(topics, 0)
     mqttc.message_callback_add(topics, on_delete_message)
     mqttc.loop_start()
     logging.info("Starting delete of topics for device %s" % (device_id))
@@ -314,6 +315,7 @@ def delete_device(device_id):
 
     mqttc.loop_stop()
     mqttc.message_callback_remove(topics)
+    mqttc.unsubscribe(topics)
     mqttc.loop_start()
     info = "Deleted topics for %s" % (device_id)
     logging.info(info)

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -447,7 +447,7 @@ def on_delete_message(mosq, userdata, msg):
     if len(msg.payload) == 0:
         return
     # Publish a retain message of zero bytes.
-    mqttc.publish(msg.topic, payload='', qos=1, retain=True)
+    mqttc.publish(msg.topic, payload='', qos=0, retain=True)
 
 def on_sensor(mosq, userdata, msg):
     if msg.topic.endswith("$ota/payload"):

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -447,7 +447,7 @@ def on_delete_message(mosq, userdata, msg):
     if len(msg.topic) == 0:
         return
     # Publish a retain message of zero bytes.
-    mqttc.publish(mst.topic, payload='', qos=1, retain=True)
+    mqttc.publish(msg.topic, payload='', qos=1, retain=True)
 
 def on_sensor(mosq, userdata, msg):
     if msg.topic.endswith("$ota/payload"):

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -301,7 +301,7 @@ def update():
 
     return info
 
-@route('/devices/<device_id>', method='DELETE')
+@route('/device/<device_id>', method='DELETE')
 def delete_device(device_id):
     topics = "%s/%s/+/+" % (MQTT_SENSOR_PREFIX, device_id)
     mqttc.message_callback_add(topics, on_delete_message)
@@ -438,7 +438,7 @@ def on_connect(mosq, userdata, rc):
 # on_delete_message handles deleting the topic the messages was received on.
 def on_delete_message(mosq, userdata, msg):
     logging.debug("Received delete callback for topic '%s'" % msg.topic)
-    if len(msg.topic) == 0
+    if len(msg.topic) == 0:
         return
     # Publish a retain message of zero bytes.
     mqttc.publish(mst.topic, payload='', qos=1, retain=True)
@@ -474,7 +474,7 @@ def on_sensor(mosq, userdata, msg):
         # Homie 2.0 uptime
         if subtopic == "$uptime/value":
             db[device]["human_uptime"] = uptime(msg.payload)
-        
+
         if device not in sensors:
             sensors[device] = {}
         sensors[device][subtopic] = msg.payload

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -308,7 +308,7 @@ def delete_device(device_id):
     logging.info("Starting delete of topics for device %s" % (device_id))
 
     # Give the callback 4 seconds before returning
-    sleep(4)
+    time.sleep(4)
 
     mqttc.message_callback_remove(topics)
     info = "Deleted topics for %s" % (device)

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -311,7 +311,7 @@ def delete_device(device_id):
     time.sleep(4)
 
     mqttc.message_callback_remove(topics)
-    info = "Deleted topics for %s" % (device)
+    info = "Deleted topics for %s" % (device_id)
     logging.info(info)
 
     return info

--- a/templates/device.tpl
+++ b/templates/device.tpl
@@ -10,7 +10,7 @@
 <h2>Homie device details</h2>
 
 <p>
-[<a href="/">Homie device inventory</a>] [<a href="/log">Log</a>]
+[<a href="/">Homie device inventory</a>] [<a href="/log">Log</a>] [<a class="delete" data-delete-url="/device/{{device}}">Delete</a>]
 </p>
 
 <h3>Details for device {{device}}</h3>
@@ -42,5 +42,26 @@
 </tr>
 %end
 </table>
+<script type="application/javascript">
+$('.delete').bind('click', function (e){
+  e.preventDefault();
+  var elem = $(this);
+  if (confirm("Are you sure to delete the file?")) {
+    $.ajax({
+      url: $(this).data('delete-url'),
+      type: 'DELETE',
+      async: true
+    })
+    .done(function() {
+      alert('Deleted device');
+      window.location.href = '/';
+    })
+    .fail(function(e) {
+      alert('Error: ' + e.statusText);
+    })
+  }
+  return false;
+})
+</script>
 </body>
 </html>

--- a/templates/device.tpl
+++ b/templates/device.tpl
@@ -3,7 +3,7 @@
 <head>
   <title>Homie device - {{device}}</title>
   <meta http-equiv="refresh" content="60" />
-
+  <script type="text/javascript" src="/jquery.min.js"></script>
   <link rel="stylesheet" href="/styles.css">
   </head>
 <body>

--- a/templates/device.tpl
+++ b/templates/device.tpl
@@ -45,7 +45,7 @@
 <script type="application/javascript">
 $('.delete').bind('click', function (e){
   e.preventDefault();
-  if (confirm("Are you sure to delete the file?")) {
+  if (confirm("Are you sure to delete this device?")) {
     $.ajax({
       url: $(this).data('delete-url'),
       type: 'DELETE',

--- a/templates/device.tpl
+++ b/templates/device.tpl
@@ -10,7 +10,7 @@
 <h2>Homie device details</h2>
 
 <p>
-[<a href="/">Homie device inventory</a>] [<a href="/log">Log</a>] [<a class="delete" data-delete-url="/device/{{device}}">Delete</a>]
+[<a href="/">Homie device inventory</a>] [<a href="/log">Log</a>] [<a class="delete" data-delete-url="/device/{{device}}" href="#">Delete</a>]
 </p>
 
 <h3>Details for device {{device}}</h3>
@@ -45,7 +45,6 @@
 <script type="application/javascript">
 $('.delete').bind('click', function (e){
   e.preventDefault();
-  var elem = $(this);
   if (confirm("Are you sure to delete the file?")) {
     $.ajax({
       url: $(this).data('delete-url'),

--- a/templates/firmware.tpl
+++ b/templates/firmware.tpl
@@ -50,12 +50,12 @@ $('.delete a').bind('click', function (e){
   var elem = $(this);
   if (confirm("Are you sure to delete the file?")) {
     $.ajax({
-      url: $(this).data('file'),
+      url: elem.data('file'),
       type: 'DELETE',
       async: true
     })
     .done(function() {
-      $(elem).closest('tr').remove();
+      elem.closest('tr').remove();
     })
     .fail(function(e) {
       alert('Error: ' + e.statusText);


### PR DESCRIPTION
Fixes #18.

This adds a delete link to the device specific details page.

When delete is called, it adds a new subscription to all of a device's topics, and a special delete handler. The delete handler will respond to any non `0 byte` payloads with a publish of 0 bytes (aka, delete). It waits a bit for the topics to get deleted, then removes the subscription and deletes the key from the inventory db. It's a bit lazy in that it just has a 2 second sleep rather than some sort of heuristic to know it's received all the messages, but it seems to work well!
