### PR TITLE
Sort device info

### DIFF
--- a/homie-ota.py
+++ b/homie-ota.py
@@ -185,7 +185,7 @@ def showdevice(device):
     if device in sensors:
         sensor = sensors[device]
 
-    return template('templates/device', device=device, data=data, sensor=sensor, sensor_keys=sorted(sensor))
+    return template('templates/device', device=device, data=data, sensor=sensor)
 
 @route('/firmware/<fw_file>', method='DELETE')
 def delete(fw_file):

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -185,7 +185,7 @@ def showdevice(device):
     if device in sensors:
         sensor = sensors[device]
 
-    return template('templates/device', device=device, data=data, sensor=sensor)
+    return template('templates/device', device=device, data=data, sensor=sensor, sensor_keys=sorted(sensor))
 
 @route('/firmware/<fw_file>', method='DELETE')
 def delete(fw_file):

--- a/templates/device.tpl
+++ b/templates/device.tpl
@@ -20,7 +20,7 @@
   <th>key</th><th>value</th>
 </tr>
 </thead>
-%for item in data:
+%for item in sorted(data):
 <tr>
   <td class="detailkey">{{item}}</td>
   <td class="detailvalue">{{ data[item] }}</td>
@@ -35,7 +35,7 @@
   <th>key</th><th>value</th>
 </tr>
 </thead>
-%for key in sensor_keys:
+%for key in sorted(sensor):
 <tr>
   <td class="detailkey">{{key}}</td>
   <td class="detailvalue">{{ sensor[key] }}</td>

--- a/templates/device.tpl
+++ b/templates/device.tpl
@@ -35,10 +35,10 @@
   <th>key</th><th>value</th>
 </tr>
 </thead>
-%for item in sensor:
+%for key in sensor_keys:
 <tr>
-  <td class="detailkey">{{item}}</td>
-  <td class="detailvalue">{{ sensor[item] }}</td>
+  <td class="detailkey">{{key}}</td>
+  <td class="detailvalue">{{ sensor[key] }}</td>
 </tr>
 %end
 </table>


### PR DESCRIPTION
This PR sorts the single device page's device info, and sensor info, alphabetically. I find this to be much easier to take in, as sometimes the ordering would just change as I made changes to the mqtt broker and various other aspects of my system. Now it's deterministic.

![image](https://cloud.githubusercontent.com/assets/115958/19701546/5d09f518-9b58-11e6-9c93-7a192f455f3b.png)
