### PR TITLE
Fix update and signal display for last version of Homie ESP8266

### DIFF
--- a/homie-ota.py
+++ b/homie-ota.py
@@ -496,8 +496,14 @@ def on_sensor(mosq, userdata, msg):
         # print "DATA", device, subtopic, msg.payload
 
         # Homie 2.0 uptime
-        if subtopic == "$uptime/value":
+        if (subtopic == "$uptime/value") or (subtopic == "$stats/uptime"):
             db[device]["human_uptime"] = uptime(msg.payload)
+            return
+
+        if key == "$stats":
+            if subkey == "signal":
+                db[device]["signal"] = str(msg.payload)
+            return
 
         if device not in sensors:
             sensors[device] = {}


### PR DESCRIPTION
I observed that last updates on Homie ESP8266 (https://github.com/marvinroger/homie-esp8266) is managing signal and uptime statistics via a different MQTT channel.