### PR TITLE
Supports version formats x.x.x and x.y.m.d

### DIFF
--- a/homie-ota.py
+++ b/homie-ota.py
@@ -355,7 +355,7 @@ def scan_firmware():
         if not fw_file.endswith('.bin'):
             continue
 
-        regex = re.compile("(.*)\-(\d+\.\d+\.\d+)\.bin")
+        regex = re.compile("(.*)\-((\d+\.\d+\.\d+\.\d+)|(\d+\.\d+.\d+))\.bin")
         regex_result = regex.search(fw_file)
 
         if not regex_result:


### PR DESCRIPTION
I like using x.y.m.d such that X is major version and y.m.d is a
timestamp for current day build.
For instance major version 1 build of 2017-02-16 would look like 1.17.2.16
Quick hack on Regex, would be nice to maybe even support x.x (2, 3 or 4 numerical parts for version)