### PR TITLE
Handling for SIGTERM

### DIFF
--- a/homie-ota.py
+++ b/homie-ota.py
@@ -10,6 +10,7 @@ from bottle import get, route, request, run, static_file, HTTPResponse, template
 import paho.mqtt.client as paho   # pip install paho-mqtt
 import StringIO
 import os
+import signal
 import sys
 import hashlib
 import logging
@@ -113,12 +114,16 @@ def generate_ota_payload(firmware):
     # ota payload is <hash>@<version>
     return "%s@%s" % (fw_hash, fw_version)
 
+def handleterm(signum, frame):
+    logging.info("SIGTERM received")
+    sys.exit(0)
+
 def exitus():
     db.sync()
     db.close()
     sensors.sync()
     sensors.close()
-    logging.debug("CIAO")
+    logging.info("CIAO")
 
 def uptime(seconds=0):
     MINUTE = 60
@@ -586,6 +591,7 @@ if __name__ == '__main__':
 
     mqttc.loop_start()
 
+    signal.signal(signal.SIGTERM, handleterm)
     atexit.register(exitus)
 
     try:


### PR DESCRIPTION
Fix for #55:
Currently the code does not handle SIGTERM. If code is run under e.g. systemd, the database is never synced to disk since systemd uses SIGTERM (default) to terminate a process. Not syncing means for instance that nodes deleted via GUI will re-appear when homie-ota is re-started.
This adds a simple handler for SIGTERM, which makes the exit function work.