### PR TITLE
Fix import of configparser in case that ConfigParser exists

### DIFF
--- a/homie-ota.py
+++ b/homie-ota.py
@@ -22,7 +22,7 @@ import re
 import base64
 
 try:
-    import ConfigParser
+    import ConfigParser as configparser
 except ImportError:
     import configparser
 

--- a/homie-ota.py
+++ b/homie-ota.py
@@ -347,10 +347,7 @@ def update():
             m.update(fwread)
             fwchecksum = m.hexdigest()
 
-            topic = "%s/%s/$implementation/ota/checksum" % (MQTT_SENSOR_PREFIX, device)
-            mqttc.publish(topic, payload=fwchecksum, qos=1, retain=False)
-
-            topic = "%s/%s/$implementation/ota/firmware" % (MQTT_SENSOR_PREFIX, device)
+            topic = "%s/%s/$implementation/ota/firmware/%s" % (MQTT_SENSOR_PREFIX, device, fwchecksum)
             mqttc.publish(topic, payload=fwpublish, qos=1, retain=False)
         except:
             pass


### PR DESCRIPTION
Otherwise it causes
    config = configparser.RawConfigParser()
NameError: name 'configparser' is not defined
