### PR TITLE
Add compatibility for devices using Homie convention < version 3.0

### DIFF
--- a/templates/inventory.tpl
+++ b/templates/inventory.tpl
@@ -25,23 +25,31 @@
 </thead>
 %for device in sorted(db):
 <tr>
-%if db[device].get('homie', 0) >= 3.0:
+%if db[device].get('homie', '1.0') >= '3.0':
    <td class="online"><img src="{{base_url}}/{{db[device].get('state', 'false')}}.png"
    		      alt="{{db[device].get('state', 'false')}}" /></td>
 %else:
   <td class="online"><img src="{{base_url}}/{{db[device].get('online', 'false')}}.png"
    		      alt="{{db[device].get('online', 'false')}}" /></td>
 %end
-
-%if db[device].get('state', 'false') == 'ready':
-   <td class="signal"><div class="pBar" data-from="0" data-to="{{ db[device].get('signal', 0) }}"></div></td>
+%if db[device].get('homie', '1.0') >= '3.0':
+   %if db[device].get('state', 'false') == 'ready':
+      <td class="signal"><div class="pBar" data-from="0" data-to="{{ db[device].get('signal', 0) }}"></div></td>
+   %else:
+      <td class="signal"><div class="pBar" data-from="0" data-to="0"></div></td>
+   %end
 %else:
-   <td class="signal"><div class="pBar" data-from="0" data-to="0"></div></td>
+   %if db[device].get('online', 'false') == 'true':
+      <td class="signal"><div class="pBar" data-from="0" data-to="{{ db[device].get('signal', 0) }}"></div></td>
+   %else:
+      <td class="signal"><div class="pBar" data-from="0" data-to="0"></div></td>
+   %end
 %end
-   <td class="device"><a href="{{base_url}}/device/{{device}}">{{device}}</a></td>
+
+<td class="device"><a href="{{base_url}}/device/{{device}}">{{device}}</a></td>
 
 %for item in ['localip', 'human_uptime']:
-  %if item in db[device] and db[device].get('state', 'false') == 'ready':
+  %if item in db[device] and (db[device].get('state', 'false') == 'ready' or db[device].get('online', 'false') == 'true'):
     <td>{{db[device][item]}}</td>
   %else:
     <td></td>


### PR DESCRIPTION
During recent update to support Homie 3.0 compatibility with older revisions of the Homie convention was broken on the device inventory page (issue #78). 

This PR adds support for older Homie devices (tested with 2.0.1) as well as keeping support for Homie 3.0 and later.