### PR TITLE
sigterm due DEBUG_SENSOR failing on specific mqtt messages

### DIFF
--- a/homie-ota.py
+++ b/homie-ota.py
@@ -542,7 +542,7 @@ def on_sensor(mosq, userdata, msg):
     elif msg.topic.endswith("$fw/name") or msg.topic.endswith("$fw/version"):
         logging.debug("FW message %s %s" % (msg.topic, str(msg.payload)))
     elif DEBUG_SENSOR:
-        logging.debug("SENSOR %s %s" % (msg.topic, str(msg.payload)))
+        logging.debug("SENSOR %s %s" % (str(msg.topic), str(msg.payload)))
 
     try:
         t = str(msg.topic)


### PR DESCRIPTION
This simple fix corrects a defect where  Homie-OTA was crashing if the DEBUG_SENSOR was enabled and specfic message topics used which python failed to cast to string.